### PR TITLE
Add links to other courses from DeepLearning.AI specialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,11 @@ _The Algorithms courses are taught in Java. If students need to learn Java, they
 
 ### Machine Learning/Data Mining
 
-[Machine Learning](https://www.coursera.org/learn/machine-learning)
+[Supervised Machine Learning: Regression and Classification](https://www.coursera.org/learn/machine-learning)
+
+[Advanced Learning Algorithms](https://www.coursera.org/learn/advanced-learning-algorithms)
+
+[Unsupervised Learning, Recommenders, Reinforcement Learning](https://www.coursera.org/learn/unsupervised-learning-recommenders-reinforcement-learning)
 
 [Intro to Machine Learning](https://www.udacity.com/course/intro-to-machine-learning--ud120)
 


### PR DESCRIPTION
According to discussion here https://discord.com/channels/744385009028431943/744388942635204610/1254522570661822504, all three courses of the DeepLearning.AI specialization on Coursera are part of the curriculum, but only link to the first course was given in this repo. This PR adds the links of the rest of the courses.